### PR TITLE
Updated Humio/LogScale documenation

### DIFF
--- a/integrations/humio.md
+++ b/integrations/humio.md
@@ -45,4 +45,4 @@ description: >-
 ![](../.gitbook/assets/humio-alertdetails.png)
 
 * Save the alert, and upon the alert, the incident will be created on ilert side as well
-* For more information about Humio Alerts please refer to the following: [https://library.humio.com/stable/docs/automated/alerts/](https://library.humio.com/stable/docs/automated/alerts/)
+* For more information about Humio Alerts please refer to the following: [https://library.humio.com/data-analysis/automated-alerts.html](https://library.humio.com/data-analysis/automated-alerts.html)

--- a/integrations/humio.md
+++ b/integrations/humio.md
@@ -1,11 +1,11 @@
 ---
 description: >-
-  Humio provides logging and observability service that gives organizations
+  CrowdStrike Falcon LogScale provides logging and observability service that gives organizations
   complete visibility to see anomalies, threats, and problems, and get to the
   root of what happened.
 ---
 
-# Humio Integration
+# CrowdStrike Falcon LogScale (Humio) Integration
 
 ## In ilert
 
@@ -22,7 +22,7 @@ description: >-
 
 ![](../.gitbook/assets/humio\_alerturl.png)
 
-## In Humio
+## In CrowdStrike Falcon LogScale
 
 * Create an Action by clicking **Alerts** -> **Actions** -> **New Action** from your dashboard
 
@@ -45,4 +45,4 @@ description: >-
 ![](../.gitbook/assets/humio-alertdetails.png)
 
 * Save the alert, and upon the alert, the incident will be created on ilert side as well
-* For more information about Humio Alerts please refer to the following: [https://library.humio.com/data-analysis/automated-alerts.html](https://library.humio.com/data-analysis/automated-alerts.html)
+* For more information about LogScale Alerts please refer to the following: [https://library.humio.com/data-analysis/automated-alerts.html](https://library.humio.com/data-analysis/automated-alerts.html)


### PR DESCRIPTION
Looks like there's a dead link in the "Humio" documentation.

Since this page was produced Humio has also changed name to Falcon LogScale, or simply LogScale, see [press release](https://www.crowdstrike.com/press-releases/crowdstrike-introduces-falcon-logscale-and-falcon-complete-logscale/).

I want to update the page accordingly, but not sure how you want to handle redirects. Could you refer to an example of a similar case or some guidance?

Full disclosure: I am employed by CrowdStrike and one of the LogScale engineers.